### PR TITLE
Made the library compatible with `@types/zingchart`

### DIFF
--- a/projects/zingchart-angular/src/lib/zingchart-angular.component.ts
+++ b/projects/zingchart-angular/src/lib/zingchart-angular.component.ts
@@ -1,6 +1,6 @@
 /// <reference path="../zingchart.d.ts" />
 import { Component, AfterViewInit, OnDestroy, Input, Output, EventEmitter, OnChanges, SimpleChanges} from '@angular/core';
-import zingchart from 'zingchart';
+import { data as zingchart } from 'zingchart';
 
 import { ZingchartAngularService } from './zingchart-angular.service';
 


### PR DESCRIPTION
Made the library compatible with `@types/zingchart` by fixing `Module '"/PROJECT_PATH/node_modules/@types/zingchart/index"' has no default export.` error.